### PR TITLE
Fix flaky test

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestPartitionManagement.java
@@ -91,6 +91,9 @@ public class TestPartitionManagement {
           // First drop any databases in catalog
           List<String> databases = client.getAllDatabases(catName);
           for (String db : databases) {
+            for (String table : client.getAllTables(catName, db)) {
+              client.dropTable(catName, db, table, true, true);
+            }
             client.dropDatabase(catName, db, true, false, true);
           }
           client.dropCatalog(catName);
@@ -98,6 +101,9 @@ public class TestPartitionManagement {
           List<String> databases = client.getAllDatabases(catName);
           for (String db : databases) {
             if (!db.equalsIgnoreCase(Warehouse.DEFAULT_DATABASE_NAME)) {
+              for (String table : client.getAllTables(catName, db)) {
+                client.dropTable(catName, db, table, true, true);
+              }
               client.dropDatabase(catName, db, true, false, true);
             }
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What is the purpose of this PR
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
- This PR fixes the error resulting from the flaky tests: org.apache.hadoop.hive.metastore.TestPartitionManagement.testPartitionDiscoveryNonDefaultCatalog
- The mentioned test may fail or pass without changes made to the source code due to non-deterministic iteration order.

### Why the tests fail
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
- The test fails because it is attempting to delete a record (DBS entry) that is referenced by another table (TBLS), which caused a violation of foreign key constraint ‘TBLS_FK1’


### Reproduce the test failure
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
- Run the tests with NonDex maven plugin. The commands to recreate the flaky test failures are:
- `mvn -pl standalone-metastore/metastore-server edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.apache.hadoop.hive.metastore.TestPartitionManagement#testPartitionDiscoveryNonDefaultCatalog
`
### Expected results
<!--
If yes, please attach a file with output from mvn dependency:tree to validate a complete upgrade of dependency.
If no, write 'No'.
-->
- The test should run successfully when run with NonDex.


### Actual Result
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
- I get the following failure :org.apache.hadoop.hive.metastore.api.MetaException: JDODataStoreException: Exception thrown flushing changes to datastore。 Root cause: ERROR 23503: DELETE on table ‘DBS’ caused a violation of foreign key constraint ‘TBLS_FK1’ for key (3). The statement has been rolled back at org.apache.hadoop.hive.metastore.TestPartitionManagement.tearDown(TestPartitionManagement.java:94)

### Fix
- Drop all tables first before dropping the databases
